### PR TITLE
Refactor repetitive calls

### DIFF
--- a/R/accounts.R
+++ b/R/accounts.R
@@ -8,13 +8,16 @@
 get_account <- function(id,instance = NULL, token = NULL, anonymous = FALSE, parse = TRUE){
   path <- paste0("api/v1/accounts/",id)
   params <- list()
-  output <- make_get_request(token = token,path = path,
-                                      instance = instance, params = params,
-                                      anonymous = anonymous)
-  if (isTRUE(parse)) {
-    output <- parse_account(output)
-  }
-  return(output)
+  # output <- make_get_request(token = token,path = path,
+  #                                     instance = instance, params = params,
+  #                                     anonymous = anonymous)
+  # if (isTRUE(parse)) {
+  #   output <- parse_account(output)
+  # }
+  # return(output)
+  process_request(token = token,path = path,instance = instance,
+                  params = params, anonymous = anonymous,
+                  parse = parse, FUN = parse_account)
 }
 
 #' Search the instance for a specific user
@@ -28,13 +31,16 @@ get_account <- function(id,instance = NULL, token = NULL, anonymous = FALSE, par
 search_accounts <- function(query,limit = 40,instance = NULL, token = NULL, anonymous = FALSE, parse = TRUE){
   path <- "/api/v1/accounts/search"
   params <- list(q=query,limit = limit)
-  output <- make_get_request(token = token,path = path,
-                                      instance = instance, params = params,
-                                      anonymous = anonymous)
-  if (isTRUE(parse)) {
-    output <- dplyr::bind_rows(lapply(output, parse_account))
-  }
-  return(output)
+  # output <- make_get_request(token = token,path = path,
+  #                                     instance = instance, params = params,
+  #                                     anonymous = anonymous)
+  # if (isTRUE(parse)) {
+  #   output <- dplyr::bind_rows(lapply(output, parse_account))
+  # }
+  # return(output)
+  process_request(token = token,path = path,instance = instance,
+                  params = params, anonymous = anonymous,
+                  parse = parse, FUN = parse_account)
 }
 
 #' Get statuses from a user
@@ -48,13 +54,16 @@ search_accounts <- function(query,limit = 40,instance = NULL, token = NULL, anon
 get_account_statuses <- function(id,instance = NULL, token = NULL, anonymous = FALSE, parse = TRUE){
   path <- paste0("api/v1/accounts/",id,"/statuses")
   params <- list()
-  output <- make_get_request(token = token,path = path,
-                             instance = instance, params = params,
-                             anonymous = anonymous)
-  if (isTRUE(parse)) {
-    output <- dplyr::bind_rows(lapply(output, parse_status))
-  }
-  return(output)
+  # output <- make_get_request(token = token,path = path,
+  #                            instance = instance, params = params,
+  #                            anonymous = anonymous)
+  # if (isTRUE(parse)) {
+  #   output <- dplyr::bind_rows(lapply(output, parse_status))
+  # }
+  # return(output)
+  process_request(token = token,path = path,instance = instance,
+                  params = params, anonymous = anonymous,
+                  parse = parse, FUN = parse_status)
 }
 
 #' Get followers of a user
@@ -74,11 +83,9 @@ get_account_followers <- function(id,max_id,since_id,limit = 40, token = NULL, p
   if (!missing(since_id)) {
     params$since_id <- since_id
   }
-  output <- make_get_request(token = token, path = path, params = params)
-  if (isTRUE(parse)) {
-    output <- dplyr::bind_rows(lapply(output, parse_account))
-  }
-  return(output)
+  process_request(token = token,path = path,
+                  params = params,
+                  parse = parse, FUN = parse_account)
 }
 #' Get accounts a user follows
 #' @inheritParams get_account_statuses
@@ -95,11 +102,14 @@ get_account_following <- function(id,max_id,since_id,limit = 40, token = NULL, p
   if (!missing(since_id)) {
     params$since_id <- since_id
   }
-  output <- make_get_request(token = token, path = path, params = params)
-  if (isTRUE(parse)) {
-    output <- dplyr::bind_rows(lapply(output, parse_account))
-  }
-  return(output)
+  # output <- make_get_request(token = token, path = path, params = params)
+  # if (isTRUE(parse)) {
+  #   output <- dplyr::bind_rows(lapply(output, parse_account))
+  # }
+  # return(output)
+  process_request(token = token,path = path,
+                  params = params,
+                  parse = parse, FUN = parse_account)
 }
 
 #' Get featured tags of a user
@@ -110,11 +120,14 @@ get_account_following <- function(id,max_id,since_id,limit = 40, token = NULL, p
 get_account_featured_tags <- function(id,token = NULL, parse = TRUE){
   path <- paste0("api/v1/accounts/",id,"/featured_tags")
   params <- list()
-  output <- make_get_request(token = token,path = path, params = params)
-  if (isTRUE(parse)) {
-    output <- dplyr::bind_rows(output)
-  }
-  return(output)
+  # output <- make_get_request(token = token,path = path, params = params)
+  # if (isTRUE(parse)) {
+  #   output <- dplyr::bind_rows(output)
+  # }
+  # return(output)
+  process_request(token = token,path = path,
+                  params = params,
+                  parse = parse, FUN = identity)
 }
 
 #' Get lists containing the user
@@ -125,11 +138,14 @@ get_account_featured_tags <- function(id,token = NULL, parse = TRUE){
 get_account_lists <- function(id,token = NULL, parse = TRUE){
   path <- paste0("api/v1/accounts/",id,"/lists")
   params <- list()
-  output <- make_get_request(token = token,path = path, params = params)
-  if (isTRUE(parse)) {
-    # output <- dplyr::bind_rows(lapply(output, parse_status))
-  }
-  return(output) #TODO: probably need to format
+  # output <- make_get_request(token = token,path = path, params = params)
+  # if (isTRUE(parse)) {
+  #   # output <- dplyr::bind_rows(lapply(output, parse_status))
+  # }
+  # return(output) #TODO: probably need to format
+  process_request(token = token,path = path,
+                  params = params,
+                  parse = parse, FUN = identity)
 }
 
 #' Find out whether a given account is followed, blocked, muted, etc.
@@ -143,8 +159,11 @@ get_account_relationships <- function(ids,token = NULL, parse = TRUE){
   ids_lst <- lapply(ids,identity)
   names(ids_lst) <- rep("id[]",length(ids_lst))
   params <- ids_lst
-  output <- make_get_request(token = token,path = path, params = params)
-  dplyr::bind_rows(output)
+  # output <- make_get_request(token = token,path = path, params = params)
+  # dplyr::bind_rows(output)
+  process_request(token = token,path = path,
+                  params = params,
+                  parse = parse, FUN = identity)
 }
 
 
@@ -155,8 +174,8 @@ get_account_relationships <- function(ids,token = NULL, parse = TRUE){
 #' @details this functions needs a user level auth token
 #' @return bookmarked statuses
 #' @export
-get_account_bookmarks <- function(id,max_id,since_id,min_id,limit = 40, token = NULL, parse = TRUE){
-  path <- paste0("api/v1/accounts/",id,"/bookmarks")
+get_account_bookmarks <- function(max_id,since_id,min_id,limit = 40, token = NULL, parse = TRUE){
+  path <- paste0("api/v1/bookmarks")
   params <- list(limit = limit)
   if (!missing(max_id)) {
     params$max_id <- max_id
@@ -167,11 +186,14 @@ get_account_bookmarks <- function(id,max_id,since_id,min_id,limit = 40, token = 
   if (!missing(min_id)) {
     params$since_id <- min_id
   }
-  output <- make_get_request(token = token, path = path, params = params)
-  if (isTRUE(parse)) {
-    output <- dplyr::bind_rows(lapply(output, parse_status))
-  }
-  return(output)
+  # output <- make_get_request(token = token, path = path, params = params)
+  # if (isTRUE(parse)) {
+  #   output <- dplyr::bind_rows(lapply(output, parse_status))
+  # }
+  # return(output)
+  process_request(token = token,path = path,
+                  params = params,
+                  parse = parse, FUN = parse_status)
 }
 
 #' Get favourites of user
@@ -181,8 +203,8 @@ get_account_bookmarks <- function(id,max_id,since_id,min_id,limit = 40, token = 
 #' @details this functions needs a user level auth token
 #' @return favourited statuses
 #' @export
-get_account_favourites <- function(id,max_id,min_id,limit = 40, token = NULL, parse = TRUE){
-  path <- paste0("api/v1/accounts/",id,"/favourites")
+get_account_favourites <- function(max_id,min_id,limit = 40, token = NULL, parse = TRUE){
+  path <- paste0("api/v1/favourites")
   params <- list(limit = limit)
   if (!missing(max_id)) {
     params$max_id <- max_id
@@ -190,11 +212,14 @@ get_account_favourites <- function(id,max_id,min_id,limit = 40, token = NULL, pa
   if (!missing(min_id)) {
     params$min_id <- min_id
   }
-  output <- make_get_request(token = token, path = path, params = params)
-  if (isTRUE(parse)) {
-    output <- dplyr::bind_rows(lapply(output, parse_status))
-  }
-  return(output)
+  # output <- make_get_request(token = token, path = path, params = params)
+  # if (isTRUE(parse)) {
+  #   output <- dplyr::bind_rows(lapply(output, parse_status))
+  # }
+  # return(output)
+  process_request(token = token,path = path,
+                  params = params,
+                  parse = parse, FUN = parse_status)
 }
 
 #' Get blocks of user
@@ -203,8 +228,8 @@ get_account_favourites <- function(id,max_id,min_id,limit = 40, token = NULL, pa
 #' @details this functions needs a user level auth token
 #' @return blocked users
 #' @export
-get_account_blocks <- function(id,max_id,since_id,limit = 40, token = NULL, parse = TRUE){
-  path <- paste0("api/v1/accounts/",id,"/blocks")
+get_account_blocks <- function(max_id,since_id,limit = 40, token = NULL, parse = TRUE){
+  path <- paste0("api/v1/blocks")
   params <- list(limit = limit)
   if (!missing(max_id)) {
     params$max_id <- max_id
@@ -212,11 +237,14 @@ get_account_blocks <- function(id,max_id,since_id,limit = 40, token = NULL, pars
   if (!missing(since_id)) {
     params$since_id <- since_id
   }
-  output <- make_get_request(token = token, path = path, params = params)
-  if (isTRUE(parse)) {
-    output <- dplyr::bind_rows(lapply(output, parse_account))
-  }
-  return(output)
+  # output <- make_get_request(token = token, path = path, params = params)
+  # if (isTRUE(parse)) {
+  #   output <- dplyr::bind_rows(lapply(output, parse_account))
+  # }
+  # return(output)
+  process_request(token = token,path = path,
+                  params = params,
+                  parse = parse, FUN = parse_account)
 }
 
 #' Get mutes of user
@@ -225,8 +253,8 @@ get_account_blocks <- function(id,max_id,since_id,limit = 40, token = NULL, pars
 #' @details this functions needs a user level auth token
 #' @return muted users
 #' @export
-get_account_mutes <- function(id,max_id,since_id,limit = 40, token = NULL, parse = TRUE){
-  path <- paste0("api/v1/accounts/",id,"/mutes")
+get_account_mutes <- function(max_id,since_id,limit = 40, token = NULL, parse = TRUE){
+  path <- paste0("api/v1/mutes")
   params <- list(limit = limit)
   if (!missing(max_id)) {
     params$max_id <- max_id
@@ -234,9 +262,12 @@ get_account_mutes <- function(id,max_id,since_id,limit = 40, token = NULL, parse
   if (!missing(since_id)) {
     params$since_id <- since_id
   }
-  output <- make_get_request(token = token, path = path, params = params)
-  if (isTRUE(parse)) {
-    output <- dplyr::bind_rows(lapply(output, parse_account))
-  }
-  return(output)
+  # output <- make_get_request(token = token, path = path, params = params)
+  # if (isTRUE(parse)) {
+  #   output <- dplyr::bind_rows(lapply(output, parse_account))
+  # }
+  # return(output)
+  process_request(token = token,path = path,
+                  params = params,
+                  parse = parse, FUN = parse_account)
 }

--- a/R/accounts.R
+++ b/R/accounts.R
@@ -40,7 +40,7 @@ search_accounts <- function(query,limit = 40,instance = NULL, token = NULL, anon
   # return(output)
   process_request(token = token,path = path,instance = instance,
                   params = params, anonymous = anonymous,
-                  parse = parse, FUN = parse_account)
+                  parse = parse, FUN = v(parse_account))
 }
 
 #' Get statuses from a user
@@ -63,7 +63,7 @@ get_account_statuses <- function(id,instance = NULL, token = NULL, anonymous = F
   # return(output)
   process_request(token = token,path = path,instance = instance,
                   params = params, anonymous = anonymous,
-                  parse = parse, FUN = parse_status)
+                  parse = parse, FUN = v(parse_status))
 }
 
 #' Get followers of a user
@@ -85,7 +85,7 @@ get_account_followers <- function(id,max_id,since_id,limit = 40, token = NULL, p
   }
   process_request(token = token,path = path,
                   params = params,
-                  parse = parse, FUN = parse_account)
+                  parse = parse, FUN = v(parse_account))
 }
 #' Get accounts a user follows
 #' @inheritParams get_account_statuses
@@ -109,7 +109,7 @@ get_account_following <- function(id,max_id,since_id,limit = 40, token = NULL, p
   # return(output)
   process_request(token = token,path = path,
                   params = params,
-                  parse = parse, FUN = parse_account)
+                  parse = parse, FUN = v(parse_account))
 }
 
 #' Get featured tags of a user
@@ -127,7 +127,7 @@ get_account_featured_tags <- function(id,token = NULL, parse = TRUE){
   # return(output)
   process_request(token = token,path = path,
                   params = params,
-                  parse = parse, FUN = identity)
+                  parse = parse, FUN = v(identity))
 }
 
 #' Get lists containing the user
@@ -145,7 +145,7 @@ get_account_lists <- function(id,token = NULL, parse = TRUE){
   # return(output) #TODO: probably need to format
   process_request(token = token,path = path,
                   params = params,
-                  parse = parse, FUN = identity)
+                  parse = parse, FUN = v(identity))
 }
 
 #' Find out whether a given account is followed, blocked, muted, etc.
@@ -163,7 +163,7 @@ get_account_relationships <- function(ids,token = NULL, parse = TRUE){
   # dplyr::bind_rows(output)
   process_request(token = token,path = path,
                   params = params,
-                  parse = parse, FUN = identity)
+                  parse = parse, FUN = v(identity))
 }
 
 
@@ -193,7 +193,7 @@ get_account_bookmarks <- function(max_id,since_id,min_id,limit = 40, token = NUL
   # return(output)
   process_request(token = token,path = path,
                   params = params,
-                  parse = parse, FUN = parse_status)
+                  parse = parse, FUN = v(parse_status))
 }
 
 #' Get favourites of user
@@ -219,7 +219,7 @@ get_account_favourites <- function(max_id,min_id,limit = 40, token = NULL, parse
   # return(output)
   process_request(token = token,path = path,
                   params = params,
-                  parse = parse, FUN = parse_status)
+                  parse = parse, FUN = v(parse_status))
 }
 
 #' Get blocks of user
@@ -244,7 +244,7 @@ get_account_blocks <- function(max_id,since_id,limit = 40, token = NULL, parse =
   # return(output)
   process_request(token = token,path = path,
                   params = params,
-                  parse = parse, FUN = parse_account)
+                  parse = parse, FUN = v(parse_account))
 }
 
 #' Get mutes of user
@@ -269,5 +269,5 @@ get_account_mutes <- function(max_id,since_id,limit = 40, token = NULL, parse = 
   # return(output)
   process_request(token = token,path = path,
                   params = params,
-                  parse = parse, FUN = parse_account)
+                  parse = parse, FUN = v(parse_account))
 }

--- a/R/datastructure.R
+++ b/R/datastructure.R
@@ -144,3 +144,10 @@ parse_poll <- function(poll, parse_date = TRUE) {
   }
   output
 }
+
+parse_context <- function(output) {
+  temp_output <- list()
+  temp_output$ancestors <- dplyr::bind_rows(lapply(output$ancestors, parse_status))
+  temp_output$descendants <- dplyr::bind_rows(lapply(output$descendants, parse_status))
+  temp_output
+}

--- a/R/timelines_statuses.R
+++ b/R/timelines_statuses.R
@@ -25,7 +25,7 @@ make_get_request <- function(token, path, params, instance = NULL, anonymous = F
     stop(paste("something went wrong. Status code:", status_code))
   }
   output <- httr::content(request_results)
-  headers <- httr::headers(request_results)
+  headers <- parse_header(httr::headers(request_results))
   attr(output, "headers") <- headers
   return(output)
 }
@@ -52,33 +52,42 @@ make_get_request <- function(token, path, params, instance = NULL, anonymous = F
 get_status <- function(id, instance = NULL, token = NULL, anonymous = FALSE, parse = TRUE) {
   # if (!anonymous) token <- check_token_rtoot(token) # TODO:check if this is needed. I do not think so
   path <- paste0("/api/v1/statuses/", id)
-  output <- make_get_request(token = token, path = path, params = list(), instance = instance, anonymous = anonymous)
-  if (isTRUE(parse)) {
-    output <- parse_status(output)
-  }
-  return(output)
+  params <- list()
+  # output <- make_get_request(token = token, path = path, params = list(), instance = instance, anonymous = anonymous)
+  # if (isTRUE(parse)) {
+  #   output <- parse_status(output)
+  # }
+  # return(output)
+  process_request(token = token,path = path,instance = instance,params = params,
+                  anonymous = anonymous,parse = parse,FUN = parse_status)
 }
 
 #' @rdname get_status
 #' @export
 get_reblogged_by <- function(id, instance = NULL, token = NULL, anonymous = FALSE, parse = TRUE) {
   path <- paste0("/api/v1/statuses/", id, "/reblogged_by")
-  output <- make_get_request(token = token, path = path, params = list(), instance = instance, anonymous = anonymous)
-  if (isTRUE(parse)) {
-    output <- dplyr::bind_rows(lapply(output, parse_account))
-  }
-  return(output)
+  params <- list()
+  # output <- make_get_request(token = token, path = path, params = list(), instance = instance, anonymous = anonymous)
+  # if (isTRUE(parse)) {
+  #   output <- dplyr::bind_rows(lapply(output, parse_account))
+  # }
+  # return(output)
+  process_request(token = token,path = path,instance = instance,params = params,
+                  anonymous = anonymous,parse = parse,FUN = parse_account)
 }
 
 #' @rdname get_status
 #' @export
 get_favourited_by <- function(id, instance = NULL, token = NULL, anonymous = FALSE, parse = TRUE) {
   path <- paste0("/api/v1/statuses/", id, "/favourited_by")
-  output <- make_get_request(token = token, path = path, params = list(), instance = instance, anonymous = anonymous)
-  if (isTRUE(parse)) {
-    output <- dplyr::bind_rows(lapply(output, parse_account))
-  }
-  return(output)
+  params <- list()
+  # output <- make_get_request(token = token, path = path, params = list(), instance = instance, anonymous = anonymous)
+  # if (isTRUE(parse)) {
+  #   output <- dplyr::bind_rows(lapply(output, parse_account))
+  # }
+  # return(output)
+  process_request(token = token,path = path,instance = instance,params = params,
+                  anonymous = anonymous,parse = parse,FUN = parse_account)
 }
 
 #' View statuses above and below this status in the thread
@@ -119,11 +128,13 @@ get_context <- function(id, instance = NULL, token = NULL, anonymous = FALSE, pa
 #' }
 get_poll <- function(id, instance = NULL, token = NULL, anonymous = FALSE, parse = TRUE) {
   path <- paste0("/api/v1/polls/", id)
-  output <- make_get_request(token = token, path = path, params = list(), instance = instance, anonymous = anonymous)
-  if (isTRUE(parse)) {
-    output <- parse_poll(output)
-  }
-  return(output)
+  # output <- make_get_request(token = token, path = path, params = list(), instance = instance, anonymous = anonymous)
+  # if (isTRUE(parse)) {
+  #   output <- parse_poll(output)
+  # }
+  # return(output)
+  process_request(token = token,path = path,instance = instance,params = params,
+                  anonymous = anonymous,parse = parse,FUN = parse_poll)
 }
 
 #' Get the public timeline
@@ -162,11 +173,14 @@ get_public_timeline <- function(local = FALSE, remote = FALSE, only_media = FALS
   if (!missing(min_id)) {
     params$min_id <- min_id
   }
-  output <- make_get_request(token = token, path = "/api/v1/timelines/public", params = params, instance = instance, anonymous = anonymous)
-  if (isTRUE(parse)) {
-    output <- dplyr::bind_rows(lapply(output, parse_status))
-  }
-  return(output)
+  path = "/api/v1/timelines/public"
+  # output <- make_get_request(token = token, path = "/api/v1/timelines/public", params = params, instance = instance, anonymous = anonymous)
+  # if (isTRUE(parse)) {
+  #   output <- dplyr::bind_rows(lapply(output, parse_status))
+  # }
+  # return(output)
+  process_request(token = token,path = path,instance = instance,params = params,
+                  anonymous = anonymous,parse = parse,FUN = parse_status)
 }
 
 #' Get hashtag timeline
@@ -196,11 +210,13 @@ get_hashtag_timeline <- function(hashtag = "rstats", local = FALSE, only_media =
     params$min_id <- min_id
   }
   path <- paste0("/api/v1/timelines/tag/", gsub("^#+", "", hashtag))
-  output <- make_get_request(token = token, path = path, params = params, instance = instance, anonymous = anonymous)
-  if (isTRUE(parse)) {
-    output <- dplyr::bind_rows(lapply(output, parse_status))
-  }
-  return(output)
+  # output <- make_get_request(token = token, path = path, params = params, instance = instance, anonymous = anonymous)
+  # if (isTRUE(parse)) {
+  #   output <- dplyr::bind_rows(lapply(output, parse_status))
+  # }
+  # return(output)
+  process_request(token = token,path = path,instance = instance,params = params,
+                  anonymous = anonymous,parse = parse,FUN = parse_status)
 }
 
 #' Get home and list timelines
@@ -225,11 +241,14 @@ get_home_timeline <- function(local = FALSE, max_id, since_id, min_id, limit = 2
   if (!missing(min_id)) {
     params$min_id <- min_id
   }
-  output <- make_get_request(token = token, path = "/api/v1/timelines/home", params = params, instance = NULL, anonymous = FALSE)
-  if (isTRUE(parse)) {
-    output <- dplyr::bind_rows(lapply(output, parse_status))
-  }
-  return(output)
+  path = "/api/v1/timelines/home"
+  # output <- make_get_request(token = token, path = "/api/v1/timelines/home", params = params, instance = NULL, anonymous = FALSE)
+  # if (isTRUE(parse)) {
+  #   output <- dplyr::bind_rows(lapply(output, parse_status))
+  # }
+  # return(output)
+  process_request(token = token,path = path,params = params,
+                  parse = parse,FUN = parse_status)
 }
 
 #' @rdname get_home_timeline
@@ -246,9 +265,11 @@ get_list_timeline <- function(list_id, max_id, since_id, min_id, limit = 20L, to
     params$min_id <- min_id
   }
   path <- paste0("/api/v1/timelines/list/", list_id)
-  output <- make_get_request(token = token, path = path, params = params, instance = NULL, anonymous = FALSE)
-  if (isTRUE(parse)) {
-    output <- dplyr::bind_rows(lapply(output, parse_status))
-  }
-  return(output)
+  # output <- make_get_request(token = token, path = path, params = params, instance = NULL, anonymous = FALSE)
+  # if (isTRUE(parse)) {
+  #   output <- dplyr::bind_rows(lapply(output, parse_status))
+  # }
+  # return(output)
+  process_request(token = token,path = path,params = params,
+                  parse = parse,FUN = parse_status)
 }

--- a/R/timelines_statuses.R
+++ b/R/timelines_statuses.R
@@ -1,35 +1,3 @@
-## Endpoints under
-## https://docs.joinmastodon.org/methods/statuses/
-## https://docs.joinmastodon.org/methods/timelines/
-
-make_get_request <- function(token, path, params, instance = NULL, anonymous = FALSE, ...) {
-  if (is.null(instance) && anonymous) {
-    stop("provide either an instance or a token")
-  }
-
-  if (is.null(instance)) {
-    token <- check_token_rtoot(token)
-    url <- prepare_url(token$instance)
-    config <- httr::add_headers(Authorization = paste('Bearer', token$bearer))
-  } else {
-    url <- prepare_url(instance)
-    config = list()
-  }
-
-  request_results <- httr::GET(httr::modify_url(url, path = path),
-                               config,
-                               query = params)
-
-  status_code <- httr::status_code(request_results)
-  if (!status_code %in% c(200)) {
-    stop(paste("something went wrong. Status code:", status_code))
-  }
-  output <- httr::content(request_results)
-  headers <- parse_header(httr::headers(request_results))
-  attr(output, "headers") <- headers
-  return(output)
-}
-
 #' View information about a specific status
 #'
 #' Query the instance for information about a specific status. [get_status] returns complete information of a status.

--- a/R/timelines_statuses.R
+++ b/R/timelines_statuses.R
@@ -24,7 +24,10 @@ make_get_request <- function(token, path, params, instance = NULL, anonymous = F
   if (!status_code %in% c(200)) {
     stop(paste("something went wrong. Status code:", status_code))
   }
-  return(httr::content(request_results))
+  output <- httr::content(request_results)
+  headers <- httr::headers(request_results)
+  attr(output, "headers") <- headers
+  return(output)
 }
 
 #' View information about a specific status
@@ -79,7 +82,7 @@ get_favourited_by <- function(id, instance = NULL, token = NULL, anonymous = FAL
 }
 
 #' View statuses above and below this status in the thread
-#' 
+#'
 #' Query the instance for information about the context of a specific status. A context contains statuses above and below a status in a thread.
 #' @inheritParams get_status
 #' @param parse logical, logical, if `TRUE`, the default, returns a named list of two tibbles, representing the ancestors (statuses above the status) and descendants (statuses below the status). Use `FALSE`  to return the "raw" list corresponding to the JSON returned from the Mastodon API.

--- a/R/timelines_statuses.R
+++ b/R/timelines_statuses.R
@@ -41,7 +41,7 @@ get_reblogged_by <- function(id, instance = NULL, token = NULL, anonymous = FALS
   # }
   # return(output)
   process_request(token = token,path = path,instance = instance,params = params,
-                  anonymous = anonymous,parse = parse,FUN = parse_account)
+                  anonymous = anonymous,parse = parse,FUN = v(parse_account))
 }
 
 #' @rdname get_status
@@ -55,7 +55,7 @@ get_favourited_by <- function(id, instance = NULL, token = NULL, anonymous = FAL
   # }
   # return(output)
   process_request(token = token,path = path,instance = instance,params = params,
-                  anonymous = anonymous,parse = parse,FUN = parse_account)
+                  anonymous = anonymous,parse = parse,FUN = v(parse_account))
 }
 
 #' View statuses above and below this status in the thread
@@ -71,15 +71,19 @@ get_favourited_by <- function(id, instance = NULL, token = NULL, anonymous = FAL
 #' }
 get_context <- function(id, instance = NULL, token = NULL, anonymous = FALSE, parse = TRUE) {
   path <- paste0("/api/v1/statuses/", id, "/context")
-  output <- make_get_request(token = token, path = path, params = list(), instance = instance, anonymous = anonymous)
-  if (isTRUE(parse)) {
-    ## The endpoint always returns both ancestors and descendants. A empty tibble is generated if there is nothing.
-    temp_output <- list()
-    temp_output$ancestors <- dplyr::bind_rows(lapply(output$ancestors, parse_status))
-    temp_output$descendants <- dplyr::bind_rows(lapply(output$descendants, parse_status))
-    output <- temp_output
-  }
-  return(output)
+  params <- list()
+  # output <- make_get_request(token = token, path = path, params = list(), instance = instance, anonymous = anonymous)
+  # if (isTRUE(parse)) {
+  #   ## The endpoint always returns both ancestors and descendants. A empty tibble is generated if there is nothing.
+  #   temp_output <- list()
+  #   temp_output$ancestors <- dplyr::bind_rows(lapply(output$ancestors, parse_status))
+  #   temp_output$descendants <- dplyr::bind_rows(lapply(output$descendants, parse_status))
+  #   output <- temp_output
+  # }
+  # return(output)
+  process_request(token = token,path = path,instance = instance,params = params,
+                  anonymous = anonymous,parse = parse,FUN = parse_context)
+
 }
 
 #' View a poll
@@ -148,7 +152,7 @@ get_public_timeline <- function(local = FALSE, remote = FALSE, only_media = FALS
   # }
   # return(output)
   process_request(token = token,path = path,instance = instance,params = params,
-                  anonymous = anonymous,parse = parse,FUN = parse_status)
+                  anonymous = anonymous,parse = parse,FUN = v(parse_status))
 }
 
 #' Get hashtag timeline
@@ -184,7 +188,7 @@ get_hashtag_timeline <- function(hashtag = "rstats", local = FALSE, only_media =
   # }
   # return(output)
   process_request(token = token,path = path,instance = instance,params = params,
-                  anonymous = anonymous,parse = parse,FUN = parse_status)
+                  anonymous = anonymous,parse = parse,FUN = v(parse_status))
 }
 
 #' Get home and list timelines
@@ -216,7 +220,7 @@ get_home_timeline <- function(local = FALSE, max_id, since_id, min_id, limit = 2
   # }
   # return(output)
   process_request(token = token,path = path,params = params,
-                  parse = parse,FUN = parse_status)
+                  parse = parse,FUN = v(parse_status))
 }
 
 #' @rdname get_home_timeline
@@ -239,5 +243,5 @@ get_list_timeline <- function(list_id, max_id, since_id, min_id, limit = 20L, to
   # }
   # return(output)
   process_request(token = token,path = path,params = params,
-                  parse = parse,FUN = parse_status)
+                  parse = parse,FUN = v(parse_status))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -10,9 +10,56 @@ print.rtoot_bearer <- function(x,...){
   invisible(x)
 }
 
+# prepare urls
 prepare_url <- function(instance){
   url <- httr::parse_url("")
   url$hostname <- instance
   url$scheme <- "https"
   url
+}
+
+# process the header of a get request
+parse_header <- function(header){
+  # rate limit fields should always be present but the link field is not always there
+  df <- tibble::tibble(rate_limit=header[["x-ratelimit-limit"]],
+                       rate_remaining=header[["x-ratelimit-remaining"]],
+                       rate_reset=format_date(header[["x-ratelimit-reset"]]))
+  if("link"%in%names(header)){
+    vars_to_search <- c("max_id","min_id","since_id")
+    links <- regmatches(header[["link"]], gregexpr("https[^>]+", header[["link"]]))[[1]]
+    query_params <- lapply(links,function(x){
+      query <- httr::parse_url(x)[["query"]]
+      query <- query[names(query)%in%vars_to_search]
+    })
+    page_param <- dplyr::bind_cols(query_params)
+
+    return(dplyr::bind_cols(df,page_param))
+  } else{
+    return(df)
+  }
+}
+
+process_request <- function(token = NULL,
+                path,
+                instance = NULL,
+                params,
+                anonymous = FALSE,
+                parse = TRUE,
+                FUN = identity
+){
+  output <- make_get_request(token = token,path = path,
+                             instance = instance, params = params,
+                             anonymous = anonymous)
+  if (isTRUE(parse)) {
+    header <- attr(output,"headers")
+    if(length(output)<1){
+      output <- tibble::tibble()
+    } else if(length(output[[1]])==1){ #TODO:fragile?
+      output <- FUN(output)
+    } else{
+      output <- dplyr::bind_rows(lapply(output, FUN))
+    }
+    attr(output,"headers") <- header
+  }
+  return(output)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -86,14 +86,23 @@ process_request <- function(token = NULL,
                              anonymous = anonymous)
   if (isTRUE(parse)) {
     header <- attr(output,"headers")
-    if(length(output)<1){
-      output <- tibble::tibble()
-    } else if(length(output[[1]])==1){ #TODO:fragile?
-      output <- FUN(output)
-    } else{
-      output <- dplyr::bind_rows(lapply(output, FUN))
-    }
+    # if(length(output)<1){
+    #   output <- tibble::tibble()
+    # } else if(length(output[[1]])==1){ #TODO:fragile?
+    #   output <- FUN(output)
+    # } else{
+    #   output <- dplyr::bind_rows(lapply(output, FUN))
+    # }
+    output <- FUN(output)
     attr(output,"headers") <- header
   }
   return(output)
+}
+
+##vectorize function
+v <- function(FUN) {
+  v_FUN <- function(x) {
+    dplyr::bind_rows(lapply(x, FUN))
+  }
+  return(v_FUN)
 }


### PR DESCRIPTION
This PR fixes the repetitive calls in all API calls with a function `process_request()` 

It also fixes some path errors in 
`get_account_bookmarks()` `get_account_favourites()` `get_account_mutes()` `get_account_blocks()`

Additionally, it exposes ratelimit and paging parameters as attributes

@chainsawriot happy to not merge if you think this interferes with your test setup too much. I did not run into problems so far
Your call! 