### PR TITLE
Add limit argument to get_status() function

### DIFF
--- a/R/timelines_statuses.R
+++ b/R/timelines_statuses.R
@@ -7,7 +7,7 @@
 #' @param instance character, the server name of the instance where the status is located. If `NULL`, the same instance used to obtain the token is used.
 #' @param anonymous some API calls do not need a token. Setting anonymous to TRUE allows to make an anonymous call if possible.
 #' @param parse logical, if `TRUE`, the default, returns a tibble. Use `FALSE`  to return the "raw" list corresponding to the JSON returned from the Mastodon API.
-#' @param limit integer number of toots to return, maximum of 40. If greater than 40 will return a max of 40. Defaults to 20.
+#' @param limit integer, number of toots to return. API maximum is 40. If limit of greater than 40 is entered, returns a max of 40. Defaults to 20.
 #' @inheritParams post_toot
 #' @return a status or a list of users
 #' @examples

--- a/R/timelines_statuses.R
+++ b/R/timelines_statuses.R
@@ -7,6 +7,7 @@
 #' @param instance character, the server name of the instance where the status is located. If `NULL`, the same instance used to obtain the token is used.
 #' @param anonymous some API calls do not need a token. Setting anonymous to TRUE allows to make an anonymous call if possible.
 #' @param parse logical, if `TRUE`, the default, returns a tibble. Use `FALSE`  to return the "raw" list corresponding to the JSON returned from the Mastodon API.
+#' @param limit integer number of toots to return, maximum of 40. If greater than 40 will return a max of 40. Defaults to 20.
 #' @inheritParams post_toot
 #' @return a status or a list of users
 #' @examples
@@ -16,13 +17,14 @@
 #' get_favourited_by(id = "109294719267373593")
 #' }
 #' @export
-get_status <- function(id, instance = NULL, token = NULL, anonymous = FALSE, parse = TRUE) {
-
-  path <- paste0("/api/v1/statuses/", id)
-  params <- list()
-
-  process_request(token = token,path = path,instance = instance,params = params,
-                  anonymous = anonymous,parse = parse,FUN = parse_status)
+get_status <- function(id, instance = NULL, token = NULL, anonymous = FALSE,
+                        parse = TRUE, limit = 20)
+{
+  path <- paste0("api/v1/accounts/", id, "/statuses")
+  params <- list(limit = limit)
+  process_request(token = token, path = path, instance = instance,
+                  params = params, anonymous = anonymous, parse = parse,
+                  FUN = v(parse_status))
 }
 
 #' @rdname get_status

--- a/man/get_instance.Rd
+++ b/man/get_instance.Rd
@@ -45,7 +45,7 @@ get_instance_trends(
 
 \item{offset}{How many accounts to skip before returning results. Default 0.}
 
-\item{limit}{integer number of toots to return, maximum of 40. If greater than 40 will return a max of 40. Defaults to 20.}
+\item{limit}{integer, number of toots to return. API maximum is 40. If limit of greater than 40 is entered, returns a max of 40. Defaults to 20.}
 
 \item{order}{'active' to sort by most recently posted statuses (default) or 'new' to sort by most recently created profiles.}
 

--- a/man/get_instance.Rd
+++ b/man/get_instance.Rd
@@ -45,7 +45,7 @@ get_instance_trends(
 
 \item{offset}{How many accounts to skip before returning results. Default 0.}
 
-\item{limit}{integer, Maximum number of results to return}
+\item{limit}{integer number of toots to return, maximum of 40. If greater than 40 will return a max of 40. Defaults to 20.}
 
 \item{order}{'active' to sort by most recently posted statuses (default) or 'new' to sort by most recently created profiles.}
 

--- a/man/get_status.Rd
+++ b/man/get_status.Rd
@@ -42,7 +42,7 @@ get_favourited_by(
 
 \item{parse}{logical, if \code{TRUE}, the default, returns a tibble. Use \code{FALSE}  to return the "raw" list corresponding to the JSON returned from the Mastodon API.}
 
-\item{limit}{integer number of toots to return, maximum of 40. If greater than 40 will return a max of 40. Defaults to 20.}
+\item{limit}{integer, number of toots to return. API maximum is 40. If limit of greater than 40 is entered, returns a max of 40. Defaults to 20.}
 }
 \value{
 a status or a list of users

--- a/man/get_status.Rd
+++ b/man/get_status.Rd
@@ -6,7 +6,14 @@
 \alias{get_favourited_by}
 \title{View information about a specific status}
 \usage{
-get_status(id, instance = NULL, token = NULL, anonymous = FALSE, parse = TRUE)
+get_status(
+  id,
+  instance = NULL,
+  token = NULL,
+  anonymous = FALSE,
+  parse = TRUE,
+  limit = 20
+)
 
 get_reblogged_by(
   id,
@@ -34,6 +41,8 @@ get_favourited_by(
 \item{anonymous}{some API calls do not need a token. Setting anonymous to TRUE allows to make an anonymous call if possible.}
 
 \item{parse}{logical, if \code{TRUE}, the default, returns a tibble. Use \code{FALSE}  to return the "raw" list corresponding to the JSON returned from the Mastodon API.}
+
+\item{limit}{integer number of toots to return, maximum of 40. If greater than 40 will return a max of 40. Defaults to 20.}
 }
 \value{
 a status or a list of users


### PR DESCRIPTION
Suggesting a _very_ tiny change to add argument `limit` to `get_status()` function in order to use Mastodon limit parameter allowing return of up to 40 items instead of the default 20. Thank you for this package!