### PR TITLE
authentication when you don't have a browser

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ URL: https://schochastics.github.io/rtoot/, https://github.com/schochastics/rtoo
 BugReports: https://github.com/schochastics/rtoot/issues
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Depends:
     R (>= 3.6)
 Imports: 

--- a/R/auth.R
+++ b/R/auth.R
@@ -9,6 +9,7 @@
 #'   path returned by `tools::R_user_dir("rtoot", "config")`.
 #' @param clipboard logical, whether to export the token to the clipboard
 #' @param verbose logical whether to display messages
+#' @param browser if `TRUE` (default) a browser window will be opened to authenticate, else the URL will be provided so you can copy/paste this into the browser yourself
 #' @details If either `name` or `path` are set to `FALSE`, the token is only
 #'   returned and not saved. If you would like to save your token as an environment variable,
 #'   please set `clipboard` to `TRUE`. Your token will be copied to clipboard in the environment variable
@@ -21,7 +22,7 @@
 #' auth_setup("mastodon.social", "public")
 #' }
 #' @export
-auth_setup <- function(instance = NULL, type = NULL, name = NULL, path = NULL, clipboard = FALSE, verbose = TRUE, browser=TRUE) {
+auth_setup <- function(instance = NULL, type = NULL, name = NULL, path = NULL, clipboard = FALSE, verbose = TRUE, browser = TRUE) {
   while (is.null(instance) || instance == "") {
     instance <- rtoot_ask(prompt = "On which instance do you want to authenticate (e.g., \"mastodon.social\")? ", pass = FALSE)
   }
@@ -71,6 +72,7 @@ get_client <- function(instance = "mastodon.social"){
 #'
 #' @param client rtoot client object created with [get_client]
 #' @param type one of "public" or "user". See details
+#' @param browser if `TRUE` (default) a browser window will be opened to authenticate, else the URL will be provided so you can copy/paste this into the browser yourself
 #' @details TBA
 #' @return a mastodon bearer token
 #' @references https://docs.joinmastodon.org/client/authorized/

--- a/man/auth_setup.Rd
+++ b/man/auth_setup.Rd
@@ -10,7 +10,8 @@ auth_setup(
   name = NULL,
   path = NULL,
   clipboard = FALSE,
-  verbose = TRUE
+  verbose = TRUE,
+  browser = TRUE
 )
 }
 \arguments{
@@ -28,6 +29,8 @@ path returned by \code{tools::R_user_dir("rtoot", "config")}.}
 \item{clipboard}{logical, whether to export the token to the clipboard}
 
 \item{verbose}{logical whether to display messages}
+
+\item{browser}{if \code{TRUE} (default) a browser window will be opened to authenticate, else the URL will be provided so you can copy/paste this into the browser yourself}
 }
 \value{
 A bearer token

--- a/man/create_token.Rd
+++ b/man/create_token.Rd
@@ -4,12 +4,14 @@
 \alias{create_token}
 \title{get a bearer token for the mastodon api}
 \usage{
-create_token(client, type = "public")
+create_token(client, type = "public", browser = TRUE)
 }
 \arguments{
 \item{client}{rtoot client object created with \link{get_client}}
 
 \item{type}{one of "public" or "user". See details}
+
+\item{browser}{if \code{TRUE} (default) a browser window will be opened to authenticate, else the URL will be provided so you can copy/paste this into the browser yourself}
 }
 \value{
 a mastodon bearer token

--- a/man/get_fedi_instances.Rd
+++ b/man/get_fedi_instances.Rd
@@ -4,7 +4,7 @@
 \alias{get_fedi_instances}
 \title{Get a list of fediverse servers}
 \usage{
-get_fedi_instances(token = "", n = 20, ...)
+get_fedi_instances(token = NA, n = 20, ...)
 }
 \arguments{
 \item{token}{token from instances.social (this is different from your Mastodon token!)}


### PR DESCRIPTION
I have a fiddly use case where I need to set things up on a machine without a browser. I've made a patch to include an extra argument to `auth_setup()` called `browser` (default `TRUE` giving the previous behaviour), which when it's `FALSE` will print the URL so one can copy and paste it into a browser locally.

Hope this is useful beyond just me!