### PR TITLE
refactor rate limit checking code in `process_request`, ref #69

### DIFF
--- a/tests/testthat/test-rate_limit.R
+++ b/tests/testthat/test-rate_limit.R
@@ -1,4 +1,4 @@
-## wait_until and rate_limit_remaining
+## wait_until ,rate_limit_remaining and break_process_request
 
 test_that("wait_until", {
   x <- capture_message(wait_until(2, 1, verbose = TRUE))
@@ -26,4 +26,49 @@ test_that("rate_limit_remaining", {
   expect_warning(rate_limit_remaining(y))
   z <- data.frame(x = c(1,2,3,4))
   expect_error(rate_limit_remaining(z))
+})
+
+test_that("break_process_request", {
+  ## rate_limit = 299
+  x1 <- readRDS("../testdata/fake_headers.RDS")
+  expect_false(break_process_request(x1))
+  expect_false(break_process_request(x1, retryonratelimit = TRUE))
+  expect_false(break_process_request(x1, retryonratelimit = TRUE, verbose = TRUE))
+  expect_false(break_process_request(x1, retryonratelimit = FALSE, verbose = TRUE))
+  ## alternative pager
+  x2 <- x1
+  names(attr(x2, "headers"))[4] <- "since_id"
+  expect_false(break_process_request(x2, pager = "since_id"))
+  expect_false(break_process_request(x2, retryonratelimit = TRUE, pager = "since_id"))
+  expect_false(break_process_request(x2, retryonratelimit = TRUE, verbose = TRUE, pager = "since_id"))
+  expect_false(break_process_request(x2, retryonratelimit = FALSE, verbose = TRUE, pager = "since_id"))
+  x3 <- x1
+  attr(x3, "headers")[["max_id"]] <- NULL
+  expect_true(break_process_request(x3, pager = "max_id"))
+  expect_true(break_process_request(x3, retryonratelimit = TRUE, pager = "max_id"))
+  expect_true(break_process_request(x3, retryonratelimit = TRUE, verbose = TRUE, pager = "max_id"))
+  expect_true(break_process_request(x3, retryonratelimit = FALSE, verbose = TRUE, pager = "max_id"))
+  ## emulate `rate_remaining` reaching zero
+  zero_x <- x1
+  attr(zero_x, "headers")[["rate_remaining"]] <- "0"
+  expect_equal(rate_limit_remaining(zero_x), 0)
+  ## retryonratelimit = FALSE
+  expect_true(break_process_request(zero_x, retryonratelimit = FALSE, pager = "max_id"))
+  expect_silent(break_process_request(zero_x, retryonratelimit = FALSE, pager = "max_id"))
+  expect_message(break_process_request(zero_x, retryonratelimit = FALSE, verbose = TRUE, pager = "max_id"), "rate limit reached")
+  ## retryonratelimit = TRUE
+  fake_current_time <- attr(zero_x, "headers")[["rate_reset"]] - 1
+  expect_false(break_process_request(zero_x, retryonratelimit = TRUE, pager = "max_id", from = fake_current_time))
+  expect_silent(break_process_request(zero_x, retryonratelimit = TRUE, pager = "max_id", from = fake_current_time))
+  expect_message(break_process_request(zero_x, retryonratelimit = TRUE, verbose = TRUE, pager = "max_id", from = fake_current_time), "1 second")
+  ## pager is null; retryonratelimit has no effect
+  zero_x_null <- zero_x
+  expect_equal(rate_limit_remaining(zero_x_null), 0)
+  attr(zero_x_null, "headers")[["max_id"]] <- NULL
+  expect_true(break_process_request(zero_x_null, pager = "max_id"))
+  expect_true(break_process_request(zero_x_null, retryonratelimit = TRUE, pager = "max_id"))
+  expect_true(break_process_request(zero_x_null, retryonratelimit = TRUE, verbose = TRUE, pager = "max_id"))
+  expect_true(break_process_request(zero_x_null, retryonratelimit = FALSE, verbose = TRUE, pager = "max_id"))
+  expect_silent(break_process_request(zero_x_null, retryonratelimit = FALSE, verbose = TRUE, pager = "max_id"))
+  expect_silent(break_process_request(zero_x_null, retryonratelimit = TRUE, verbose = TRUE, pager = "max_id"))
 })


### PR DESCRIPTION
* Testable + unit tests
* Reduce cyclomatic complexity
* Using semantic variable name (`api_response` vs `tmp`)